### PR TITLE
add :* to cloudwatch log arn in IAM (terraform no longer adds)

### DIFF
--- a/lambda_security.tf
+++ b/lambda_security.tf
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "lambda_access_policy" {
   statement {
     effect    = "Allow"
     actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
-    resources = [aws_cloudwatch_log_group.lambda_log_group.arn]
+    resources = ["${aws_cloudwatch_log_group.lambda_log_group.arn}:*"]
   }
 
   statement {


### PR DESCRIPTION
## Purpose of Change
Per the Terraform [AWS Provider Changelog](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md)
> v3.0.0 (July 31,2020) Automatically trim :* suffix from arn attribute

Therefore if IAM policies got recreated after that point, lambdas would stop being able to write to the logs until we explicitly added the ":*" in their cloudwatch logs policy. 

## What Changed
- explicitly added the ":*" in the cloudwatch logs policy of this shared module

## Change Tested
- successfully tested with ecats API which uses this module; this change resolved the absence of logs from the lambda function.