### PR TITLE
Additional outputs

### DIFF
--- a/lambda_security.tf
+++ b/lambda_security.tf
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "lambda_access_policy" {
   statement {
     effect    = "Allow"
     actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
-    resources = [aws_cloudwatch_log_group.lambda_log_group.arn]
+    resources = ["${aws_cloudwatch_log_group.lambda_log_group.arn}:*"]
   }
 
   statement {

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,13 +18,13 @@ output "kms_arn" {
   value       = aws_kms_key.key.arn
 }
 
-output "parameters_arn" {
-  description = "ARN for SSM secret names"
-  value       = aws_ssm_parameter.secure_param[*].arn
-}
+# output "parameters_arn" {
+#   description = "ARN for SSM secret names"
+#   value       = aws_ssm_parameter.secure_param[count.index].arn
+# }
 
 output "security_group" {
   description = "Security group for Lambda in VPC"
-  value       = aws_security_group.api_rules[*].id
+  value       = aws_security_group.api_rules[count.index].id
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,14 @@ output "kms_arn" {
   description = "AWS KMS key ID used to encrypt secrets, in case you wish to use it with other services."
   value       = aws_kms_key.key.arn
 }
+
+output "parameters_arn" {
+  description = "ARN for SSM secret names"
+  value       = aws_ssm_parameter.secure_param.arn
+}
+
+output "security_group" {
+  description = "Security group for Lambda in VPC"
+  value       = aws_security_group.api_rules.id
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,6 +25,6 @@ output "kms_arn" {
 
 output "security_group" {
   description = "Security group for Lambda in VPC"
-  value       = aws_security_group.api_rules[count.index].id
+  value       = aws_security_group.api_rules[*].id
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,11 +20,11 @@ output "kms_arn" {
 
 output "parameters_arn" {
   description = "ARN for SSM secret names"
-  value       = aws_ssm_parameter.secure_param.arn
+  value       = aws_ssm_parameter.secure_param[*].arn
 }
 
 output "security_group" {
   description = "Security group for Lambda in VPC"
-  value       = aws_security_group.api_rules.id
+  value       = aws_security_group.api_rules[*].id
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,10 +18,10 @@ output "kms_arn" {
   value       = aws_kms_key.key.arn
 }
 
-# output "parameters_arn" {
-#   description = "ARN for SSM secret names"
-#   value       = aws_ssm_parameter.secure_param[count.index].arn
-# }
+output "parameters_arn" {
+  description = "ARN for SSM secret names"
+  value       = aws_ssm_parameter.secure_param[*].arn
+}
 
 output "security_group" {
   description = "Security group for Lambda in VPC"


### PR DESCRIPTION
Updated the outputs.tf to obtain and use security groups and parameter ARNs for the additional lambda in the ADO-Sailpoint-Integration-App:

parameter_arns
security_group

After some troubleshooting and stackoverflow-ing, I've successfully made use of the outputts:
![image](https://user-images.githubusercontent.com/17802293/104244198-911d3400-5427-11eb-9ef5-043da2cbb72f.png)

![image](https://user-images.githubusercontent.com/17802293/104244217-9c705f80-5427-11eb-828b-83d2f46f0195.png)

