### PR TITLE
Develop to Stable

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -18,13 +18,13 @@ output "kms_arn" {
   value       = aws_kms_key.key.arn
 }
 
-output "parameters_arn" {
-  description = "ARN for SSM secret names"
-  value       = aws_ssm_parameter.secure_param[*].arn
-}
+# output "parameters_arn" {
+#   description = "ARN for SSM secret names"
+#   value       = aws_ssm_parameter.secure_param[count.index].arn
+# }
 
 output "security_group" {
   description = "Security group for Lambda in VPC"
-  value       = aws_security_group.api_rules[*].id
+  value       = aws_security_group.api_rules[count.index].id
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,14 @@ output "kms_arn" {
   description = "AWS KMS key ID used to encrypt secrets, in case you wish to use it with other services."
   value       = aws_kms_key.key.arn
 }
+
+output "parameters_arn" {
+  description = "ARN for SSM secret names"
+  value       = aws_ssm_parameter.secure_param.arn
+}
+
+output "security_group" {
+  description = "Security group for Lambda in VPC"
+  value       = aws_security_group.api_rules.id
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,6 +25,6 @@ output "kms_arn" {
 
 output "security_group" {
   description = "Security group for Lambda in VPC"
-  value       = aws_security_group.api_rules[count.index].id
+  value       = aws_security_group.api_rules[*].id
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,11 +20,11 @@ output "kms_arn" {
 
 output "parameters_arn" {
   description = "ARN for SSM secret names"
-  value       = aws_ssm_parameter.secure_param.arn
+  value       = aws_ssm_parameter.secure_param[*].arn
 }
 
 output "security_group" {
   description = "Security group for Lambda in VPC"
-  value       = aws_security_group.api_rules.id
+  value       = aws_security_group.api_rules[*].id
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,10 +18,10 @@ output "kms_arn" {
   value       = aws_kms_key.key.arn
 }
 
-# output "parameters_arn" {
-#   description = "ARN for SSM secret names"
-#   value       = aws_ssm_parameter.secure_param[count.index].arn
-# }
+output "parameters_arn" {
+  description = "ARN for SSM secret names"
+  value       = aws_ssm_parameter.secure_param[*].arn
+}
 
 output "security_group" {
   description = "Security group for Lambda in VPC"


### PR DESCRIPTION
added a couple of outputs that are being used in the ADO-Sailpoint-Integration-App repository.
The outputs are used instead of hardcoding security group information and ARNs.