### PR TITLE
IAC S3 Resource Update

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -54,9 +54,13 @@ resource "aws_cloudwatch_log_group" "lambda_log_group" {
 # This way, you get the full 250MB to play with.
 resource "aws_s3_bucket" "app_code_bucket" {
   bucket = "${local.application_name}-code-deployment"
-  acl    = "private"
 
   tags = local.tags
+}
+
+resource "aws_s3_bucket_acl" "app_code_acl" {
+  bucket = aws_s3_bucket.app_code_bucket.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_object" "app_code_s3_upload" {


### PR DESCRIPTION
### Overview
This PR covers an IAC update to the AWS S3 Bucket resource based on the terraform/aws version 4.0.x:
https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.0.0
Referring to the following line:
> resource/aws_s3_bucket: The acl and grant arguments have been deprecated and are now read-only. Use the aws_s3_bucket_acl resource instead. (https://github.com/hashicorp/terraform-provider-aws/issues/22537)

### Note
Also, not sure if this should have gone into 'develop' first, then into 'stable', so please correct me if I'm wrong here. 