### PR TITLE
Update variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "runtime_env" {
 # Has sane defaults, probably don't need to set these yourself
 variable "runtime_version" {
     description = "AWS Lambda runtime to use"
-    default = "nodejs12.x"
+    default = "nodejs16.x"
 }
 
 variable "runtime_memory" {


### PR DESCRIPTION
Updating the default value of the runtime_version variable.  From 12.x to 16.x This is needed because AWS no longer supports nodeJS12.x, this could be a breaking change if applications are not supplying this value.