### PR TITLE
AARP-437 AWS Provider & Node.js Version Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following options can be passed in to the module:
 | lambda_vpc_id       | No        | Private network ID. Specify if accessing on-campus resources | *none*             | 
 | lambda_subnet_ids   | No        | Network IP blocks. Specify if accessing on-campus resources  | []                 | 
 | runtime_memory      | No        | Memory for Lambda runtime                                    | 128                | 
-| runtime_version     | No        | Version of NodeJS to use                                     | nodejs20.x         | 
+| runtime_version     | No        | Version of NodeJS to use                                     | nodejs22.x         | 
 | runtime_timeout     | No        | Max runtime for a Lambda execution                           | 30                 | 
 | log_retention_days  | No        | Retention period for CloudWatch logs                         | 14                 | 
 | source_zip_excludes | No        | Files/folders to exclude from the source code zip file       | []                 | 

--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
     required_providers {
         aws = {
             source = "hashicorp/aws"
-            version = "~> 5.0"
+            version = "~> 6.0"
         }
     }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "runtime_env" {
 # Has sane defaults, probably don't need to set these yourself
 variable "runtime_version" {
     description = "AWS Lambda runtime to use"
-    default = "nodejs20.x"
+    default = "nodejs22.x"
 }
 
 variable "runtime_memory" {


### PR DESCRIPTION
[AARP-437](https://nuitadminsystems.atlassian.net/browse/AARP-437)
- This release updates the AWS provider version to its latest version ~6.0 along and Node.js to version 22.